### PR TITLE
Options to specify the query endpoint

### DIFF
--- a/lib/wikidata-taxonomy.js
+++ b/lib/wikidata-taxonomy.js
@@ -14,13 +14,16 @@ wdt.taxonomy = (id, env) => {
 
   var executeQuery = function(sparql) {
     var options = {
-      uri: 'https://query.wikidata.org/sparql',
+      uri: env.endpoint,
       qs: {
         format: 'json',
         query: sparql
       }
     }
     if (env.post) options.method = 'POST'
+    if (env.endpointUser || env.endpointPassword) options.auth = {}
+    if (env.endpointUser) options.auth.user = env.endpointUser
+    if (env.endpointPassword) options.auth.password = env.endpointPassword
     return request(options).then(wdk.simplifySparqlResults)
   };
 

--- a/wdtaxonomy.js
+++ b/wdtaxonomy.js
@@ -28,6 +28,9 @@ program
   .option('-r, --reverse', 'get superclasses instead')
   .option('-s, --sparql', 'print SPARQL query and exit')
   .option('-t, --total', 'count total number of instances')
+  .option('-e, --endpoint <url>', 'Sparql endpoint to query (defaults to query.wikidata.org)')
+  .option('-eu, --endpoint-user <url>', 'User to the sparql endpoint')
+  .option('-ep, --endpoint-password <url>', 'Password to the sparql endpoint')
   .option('-v, --verbose', 'show verbose error messages')
   .description('extract taxonomies from Wikidata')
   .action(function(wid, env) {
@@ -50,6 +53,7 @@ program
     }
 
     env.language = env.language || 'en' // TOOD: get from POSIX?
+    env.endpoint = env.endpoint || 'https://query.wikidata.org/sparql'
     format       = env.format || 'tree'
 
     if (!format.match(/^(tree|csv|json|ndjson)$/)) {


### PR DESCRIPTION
It is possible to [install a wikidata endpoint on your own server](https://www.mediawiki.org/wiki/Wikidata_query_service/User_Manual#Standalone_service) if you wish or need to have no timeout on queries, which is what we have done at Concured. This change allows for powerusers to query their own server(s).